### PR TITLE
[프로그래머스][2018 KAKAO BLIND RECRUITMENT] 추석 트래픽 (level 3) 해결

### DIFF
--- a/src/main/java/week4/question3/Solution.java
+++ b/src/main/java/week4/question3/Solution.java
@@ -4,9 +4,64 @@
  */
 package week4.question3;
 
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
 class Solution {
     public int solution(String[] lines) {
         int answer = 0;
+        List<Traffic> trafficList = new ArrayList<Traffic>();
+        for (String line : lines){
+            trafficList.add(new Traffic(line));
+        }
+
+        for (int i = 0; i <trafficList.size(); i++){
+            int count = 0;
+            long startSection = trafficList.get(i).startTime;
+            long endSection = startSection + 1000;
+
+            for (int j = 0; j < trafficList.size(); j++) {
+                if (startSection <= trafficList.get(i).startTime
+                        && trafficList.get(i).startTime < endSection) {
+                    count++;
+                } else if (startSection <= trafficList.get(i).endTime
+                        && trafficList.get(i).endTime < endSection) {
+                    count++;
+                } else if (startSection <= trafficList.get(i).startTime
+                        && trafficList.get(i).endTime <= endSection) {
+                    count++;
+                }
+                answer = count > answer ? count : answer;
+            }
+
+        }
+
         return answer;
+    }
+}
+class Traffic {
+    SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss.SSS");
+    long startTime;
+    long endTime;
+    float processingTime;
+
+    Traffic(String line){
+        parseLog(line);
+    }
+
+    private void parseLog(String line){
+        String[] logs = line.split(" ");
+        this.processingTime = Float.parseFloat(logs[2].split("s")[0]);
+        try {
+            this.endTime = dateFormat.parse(logs[0] + " " + logs[1]).getTime();
+            this.startTime = endTime - (long)(processingTime*1000) + 1;
+        } catch (Exception e){
+            System.out.println("데이터 포맷 에러");
+            e.printStackTrace();
+        }
+        System.out.println(dateFormat.format(startTime));
+        System.out.println(dateFormat.format(endTime));
     }
 }

--- a/src/main/java/week4/question3/Solution.java
+++ b/src/main/java/week4/question3/Solution.java
@@ -6,7 +6,6 @@ package week4.question3;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 class Solution {
@@ -17,28 +16,29 @@ class Solution {
             trafficList.add(new Traffic(line));
         }
 
-        for (int i = 0; i <trafficList.size(); i++){
-            int count = 0;
-            long startSection = trafficList.get(i).startTime;
-            long endSection = startSection + 1000;
-
-            for (int j = 0; j < trafficList.size(); j++) {
-                if (startSection <= trafficList.get(i).startTime
-                        && trafficList.get(i).startTime < endSection) {
-                    count++;
-                } else if (startSection <= trafficList.get(i).endTime
-                        && trafficList.get(i).endTime < endSection) {
-                    count++;
-                } else if (startSection <= trafficList.get(i).startTime
-                        && trafficList.get(i).endTime <= endSection) {
-                    count++;
-                }
-                answer = count > answer ? count : answer;
-            }
-
-        }
+        // 요청량이 변하는 순간은 각 로그의 시작과 끝뿐이다.
+        answer = getCountMax(trafficList, true, answer);
+        answer = getCountMax(trafficList, false, answer);
 
         return answer;
+    }
+    private int getCountMax (List<Traffic> trafficList, boolean isStart, int maxCount){
+        for (int i = 0; i <trafficList.size(); ++i){
+            int count = 0;
+            long startSection = isStart ? trafficList.get(i).startTime : trafficList.get(i).endTime;
+            long endSection = startSection + 1000;
+
+            for (int j = 0; j < trafficList.size(); ++j) {
+                if ((startSection <= trafficList.get(j).startTime && trafficList.get(j).startTime < endSection)
+                        || (startSection <= trafficList.get(j).endTime && trafficList.get(j).endTime < endSection)
+                        || (trafficList.get(j).startTime<=startSection && endSection<=trafficList.get(j).endTime)) {
+                    count++;
+                }
+
+                maxCount = Math.max(maxCount, count);
+            }
+        }
+        return maxCount;
     }
 }
 class Traffic {
@@ -61,7 +61,5 @@ class Traffic {
             System.out.println("데이터 포맷 에러");
             e.printStackTrace();
         }
-        System.out.println(dateFormat.format(startTime));
-        System.out.println(dateFormat.format(endTime));
     }
 }


### PR DESCRIPTION
문제가 정말정말 어려웠네요. 문제 이해는 했는데 방법을 못찾아서 한참 해맸습니다.
Date클래스로 포맷팅하면 끝날 줄 알았는데 본격적인 문제의 시작은 그 다음이더군요. 별에별 생각을 다하다가 시작점부터 1초까지를 모두 카운트했다가 실패하고 [블로그](https://velog.io/@hyeon930/%ED%94%84%EB%A1%9C%EA%B7%B8%EB%9E%98%EB%A8%B8%EC%8A%A4-%EC%B6%94%EC%84%9D-%ED%8A%B8%EB%9E%98%ED%94%BD-Java)에서 다른 사람이 짠 코드를 보고 어떤 부분이 문제인지 알고 고쳤습니다.  카카오 해설의 `요청량이 변하는 순간은 각 로그의 시작과 끝뿐임을 알 수 있습니다. `이 말이 키포인트네요.

`Traffic 클래스`
- startTime, endTime을 Date의 long형식으로 가지고 있고, float로 processTime(작업시간)을 들고 있습니다.
- Traffic 생성자에서는 parseLog 메서드를 통해 SimpleDateFormat으로 "yyyy-MM-dd hh:mm:ss.SSS"형식의 데이터로 파싱하여 startTime, endTime을 계산하여 넣습니다. 마찬가지로 s문자열을 잘라내어 Float으로 파싱하여 processTime에 저장합니다.

`getCountMax 메서드`
- startSection ~ endSection (1초)간에 이 값 사이에 있는 트래픽을 찾아냅니다.
    (1) startTime이 startSection보다 크고, startTime이 endSection보다 작은 경우
    (2) endTime이 startSection보다 크고, endTime이 endSection보다 작은 경우
    (3) startTime이 startSection보다 작고, endTime이 startSection보다 큰 경우
위 세가지 경우일 때 트래픽은 해당 구간 안에 포함되어 있기 때문에 count를 증가시켜, 가장 트래픽이 많은 구간을 찾아냅니다. 이 때, 요청량이 변하는 순간은 각 로그의 시작과 끝 + 1초 구간이기 때문에, 해당 구간을 startSection에 넣어 구간을 산정합니다.

`solution` 
1. 들어온 Log값을 Traffic 클래스를 통해 파싱하여 startTime, endTime을 저장하고, List<Traffic>에 저장해둡니다.
2. getCountMax 메서드를 호출하여, startSection에 startTime을 넣은 구간의 최대 카운트를 answer에 넣습니다.
3. getCountMax 메서드를 호출하여, startSection에 endTime을 넣은 구간의 최대 카운트를 answer에 넣습니다.
4. 결과를 반환합니다.